### PR TITLE
Bootstrap testing framework

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,0 +1,6 @@
+fixtures:
+  # use the forge modules so we can easily pin to a specific version
+  forge_modules:
+    stdlib: "puppetlabs/stdlib"
+  symlinks:
+    grokmirror: "#{source_dir}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,41 @@
+*.swp
+pkg
+
+*.gem
+*.rbc
+/.config
+/coverage/
+/InstalledFiles
+/pkg/
+/spec/reports/
+/spec/examples.txt
+/test/tmp/
+/test/version_tmp/
+/tmp/
+
+## Specific to RubyMotion:
+.dat*
+.repl_history
+build/
+
+## Documentation cache and generated files:
+/.yardoc/
+/_yardoc/
+/doc/
+/rdoc/
+
+strings.json
+
+## Environment normalization:
+/.bundle/
+/vendor/bundle
+/lib/bundler/man/
+
+# for a library or gem, you might want to ignore these files since the code is
+# intended to run in multiple environments; otherwise, check them in:
+Gemfile.lock
+.ruby-version
+.ruby-gemset
+
+# unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
+.rvmrc

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+---
+sudo: false
+language: ruby
+cache: bundler
+bundler_args: --without system_tests
+script: 'bundle exec rake validate lint spec'
+notifications:
+  email:
+    - konstantin+travisci@linuxfoundation.org
+matrix:
+  fast_finish: true
+  include:
+    - rvm: 2.1.6
+      env: PUPPET_GEM_VERSION="~> 4.0" STRICT_VARIABLES="yes"

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,12 @@
+source 'https://rubygems.org'
+
+puppetversion = ENV.key?('PUPPET_VERSION') ? "#{ENV['PUPPET_VERSION']}" : ['>= 3.3']
+gem 'puppet', puppetversion
+gem 'puppetlabs_spec_helper', '>= 0.8.2'
+gem 'puppet-lint', '>= 1.0.0'
+gem 'facter', '>= 1.7.0'
+gem 'rspec'
+gem 'rspec-puppet'
+gem 'rspec-puppet-facts'
+gem 'metadata-json-lint'
+gem 'puppet-strings'

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+describe 'grokmirror' do
+  on_supported_os.each do |os, facts|
+    context "on #{os} with defaults for all parameters" do
+      it { should compile }
+      it { should contain_class('grokmirror') }
+    end
+  end
+end
+
+# vi: ts=2 sw=2 sts=2 et :

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,1 +1,9 @@
+require 'rspec-puppet-facts'
 require 'puppetlabs_spec_helper/module_spec_helper'
+
+include RspecPuppetFacts
+RSpec.configure do |config|
+  config.formatter = :documentation
+end
+
+at_exit { RSpec::Puppet::Coverage.report! }


### PR DESCRIPTION
- Add .fixtures.yml
- Add .gitignore
- Add Gemfile
- Update spec_helper for better documentation
- Add puppet-facts based initial test template
- Add Travis-CI configuration template

NOTE: tests fail at present since there is currently a parameter named
loglevel which happens to be a global metaparam.

Signed-off-by: Andrew Grimberg agrimberg@linuxfoundation.org
